### PR TITLE
'feature/singleton-scripting-define' to 'master'

### DIFF
--- a/Scripts/Runtime/MenuHandler.cs
+++ b/Scripts/Runtime/MenuHandler.cs
@@ -16,6 +16,26 @@ namespace Vulpes.Menus
         private Canvas canvas;
         private IMenuScreen[] screens;
 
+#if VULPES_MENUS_SINGLETON
+        private static MenuHandler instance;
+
+        public static MenuHandler Instance 
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindObjectOfType<MenuHandler>(false);
+                    if (instance == null)
+                    {
+                        Debug.LogError($"Could not find an active MenuHandler instance.");
+                    }
+                }
+                return instance;
+            }
+        }
+#endif
+
         /// <summary>
         /// Used to control visibility of all screens managed by this handler.
         /// </summary>


### PR DESCRIPTION
Allows the MenuHandler to be accessed as a singleton instance if 'VULPES_MENUS_SINGLETON' is added to a Unity Project's scripting define symbols.

Note: This is essentially a lazy compromise, this singleton instance is not flagged to not be destroyed on load, and does not handle cases where multiple MenuHandlers are present in the scene hierarchy.